### PR TITLE
Added a benchmark for map overlap

### DIFF
--- a/dask/benchmarks/array_overlap.py
+++ b/dask/benchmarks/array_overlap.py
@@ -1,0 +1,18 @@
+from dask import array as da
+from dask.array.overlap import map_overlap
+
+from .common import DaskSuite, rnd
+
+class MapOverlap(DaskSuite):
+    params = [[(100,) * 3, (50, 512, 512)],
+              ['reflect', 'periodic', 'nearest', 'none'] ]
+    param_names = ['shape', 'boundary']
+
+
+    def setup(self, shape, boundary):
+        arr = da.ones(shape, chunks=[s//2 for s in shape])
+        self.arr = arr.persist()
+
+    def time_map_overlap(self, shape, boundary):
+        map_overlap(self.arr, lambda x: x,
+            depth=1, boundary=boundary, trim=True).compute()


### PR DESCRIPTION
Current master as of Sept 16
```
➤ asv dev -b MapOverlap
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_mark_miniconda3_envs_dask-dev_bin_python
[ 50.00%] ··· array_overlap.MapOverlap.time_map_overlap
[ 50.00%] ··· ================= ========== ========== ========== ==========
              --                                  boundary
              ----------------- -------------------------------------------
                    shape        reflect    periodic   nearest      none
              ================= ========== ========== ========== ==========
               (100, 100, 100)   88.0±0ms   67.6±0ms   82.6±0ms   43.5±0ms
                (50, 512, 512)   127±0ms    121±0ms    99.5±0ms   114±0ms
              ================= ========== ========== ========== ==========
```

With PR https://github.com/dask/dask/pull/3964

```
mark@xps:~/g/d/dask|map_overlap_benchmark⚡?
➤ asv dev -b MapOverlap
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_mark_miniconda3_envs_dask-dev_bin_python
[ 50.00%] ··· array_overlap.MapOverlap.time_map_overlap
[ 50.00%] ··· ================= ========== ========== ========== ==========
              --                                  boundary
              ----------------- -------------------------------------------
                    shape        reflect    periodic   nearest      none
              ================= ========== ========== ========== ==========
               (100, 100, 100)   86.1±0ms   71.6±0ms   93.0±0ms   42.5±0ms
                (50, 512, 512)   104±0ms    120±0ms    110±0ms    56.5±0ms
              ================= ========== ========== ========== ==========

```