### PR TITLE
Use persist instead of compute for MapOverlap

### DIFF
--- a/dask/benchmarks/array_overlap.py
+++ b/dask/benchmarks/array_overlap.py
@@ -15,4 +15,4 @@ class MapOverlap(DaskSuite):
 
     def time_map_overlap(self, shape, boundary):
         map_overlap(self.arr, lambda x: x,
-            depth=1, boundary=boundary, trim=True).compute()
+            depth=1, boundary=boundary, trim=True).persist()


### PR DESCRIPTION
@TomAugspurger I would like the benchmark to use persist since I don't want to benchmark the final blocking.

```
➤ asv dev -b MapOverlap
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_mark_miniconda3_envs_dask-dev_bin_python
[ 50.00%] ··· array_overlap.MapOverlap.time_map_overlap
[ 50.00%] ··· ================= ========== ========== ========== ==========
              --                                  boundary
              ----------------- -------------------------------------------
                    shape        reflect    periodic   nearest      none
              ================= ========== ========== ========== ==========
               (100, 100, 100)   82.8±0ms   69.8±0ms   74.1±0ms   36.8±0ms
                (50, 512, 512)   91.4±0ms   82.4±0ms   79.3±0ms   83.3±0ms
              ================= ========== ========== ========== ==========
```

with PR https://github.com/dask/dask/pull/3964

```
mark@xps:~/g/d/dask|map_overlap_benchmark⚡*
➤ asv dev -b MapOverlap
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_home_mark_miniconda3_envs_dask-dev_bin_python
[ 50.00%] ··· array_overlap.MapOverlap.time_map_overlap
[ 50.00%] ··· ================= ========== ========== ========== ==========
              --                                  boundary
              ----------------- -------------------------------------------
                    shape        reflect    periodic   nearest      none
              ================= ========== ========== ========== ==========
               (100, 100, 100)   87.4±0ms   69.8±0ms   70.6±0ms   20.3±0ms
                (50, 512, 512)   90.0±0ms   83.0±0ms   78.1±0ms   31.8±0ms
              ================= ========== ========== ========== ==========
```