### PR TITLE
Timing with resources

### DIFF
--- a/distributed/benchmarks/client.py
+++ b/distributed/benchmarks/client.py
@@ -3,9 +3,8 @@ import copy
 
 import time
 
-from dask import delayed
-from distributed import Client, Worker, wait, LocalCluster
-
+from dask import delayed, config
+from distributed import Client, Worker, wait, LocalCluster, stealing
 
 def slowinc(x, delay=0.02):
     time.sleep(delay)
@@ -36,12 +35,16 @@ class ClientSuite(object):
 
 
 class WorkerRestrictionsSuite(object):
-
-    params = [{"resource":1},None]
-
-    def setup(self,resource):
+    
+    params = ([1,None], [0.01, 0.1,1,100])
+    param_names = ["resource","steal_interval"]
+    
+    def setup(self,resource,steal_interval):
+        config.set({"distributed.scheduler.work-stealing-interval":steal_interval})
+        rdict = {"resource":resource} if resource else None
         cluster = LocalCluster(n_workers=1, threads_per_worker=1,
-                               resources=resource, worker_class=Worker)
+                               resources=rdict, worker_class=Worker)
+
         spec = copy.deepcopy(cluster.new_worker_spec())
         
         if resource:
@@ -52,23 +55,28 @@ class WorkerRestrictionsSuite(object):
 
         self.client = client
 
-    def teardown(self,resource):
+    def teardown(self,resource,steal_interval):
         self.client.close()
 
-    def time_trivial_tasks(self,resource):
+    def time_trivial_tasks(self,resource,steal_interval):
         """
         Benchmark measuring the improvment from allowing new workers
         to steal tasks with resource restrictions.
         """
         client = self.client
-
+        rdict = {"resource":resource} if resource else None
         info = client.scheduler_info()
         workers = list(info['workers'])
         futures = client.map(slowinc, range(10),
-                             delay=0.1, resources=resource)
+                             delay=0.1, resources=rdict)
         client.cluster.scale(len(workers) + 1)
 
         wait(futures)
         new_worker = client.cluster.workers[2]
-        # assert new_worker.available_resources == {'resource': 1}
+        if resource:
+            assert new_worker.available_resources == rdict
+        
+        steal_plug = stealing.WorkStealing(client.cluster.scheduler)
+        assert steal_plug._pc.callback_time == steal_interval
         # assert len(new_worker.task_state)
+


### PR DESCRIPTION
@TomAugspurger, this will work once @lr4d has merged his changes to allow configurable work stealing intervals for the scheduler (https://github.com/dask/distributed/pull/3523).

 It looks like on the branch to fix job stealing with arbitrary resources (https://github.com/dask/distributed/pull/3069) the scheduler is slower once resources are specified but is still much better than master (or what will soon be master... add_work_stealing_callback_config from lr4d). 

On add_work_stealing_callback_config:

```
========== ========= ========= ========= =========
--                      steal_interval
---------- ---------------------------------------
resource     0.01      0.1        1        100
========== ========= ========= ========= =========
  1        1.08±0s   1.06±0s   1.07±0s   1.07±0s
 None      436±0ms   430±0ms   436±0ms   436±0ms
========== ========= ========= ========= =========
```


On https://github.com/dask/distributed/pull/3069:
```
========== ========= ========= ========= =========
--                      steal_interval
---------- ---------------------------------------
resource     0.01      0.1        1        100
========== ========= ========= ========= =========
  1        625±0ms   542±0ms   547±0ms   644±0ms
 None      428±0ms   425±0ms   431±0ms   438±0ms
========== ========= ========= ========= =========
```