### PR TITLE
Close LocalCluster in teardown

### DIFF
--- a/distributed/benchmarks/client.py
+++ b/distributed/benchmarks/client.py
@@ -56,7 +56,7 @@ class WorkerRestrictionsSuite(object):
         self.client = client
 
     def teardown(self,resource,steal_interval):
-        self.cluster.close()
+        self.client.shutdown()
         self.client.close()
 
     def time_trivial_tasks(self,resource,steal_interval):
@@ -80,4 +80,3 @@ class WorkerRestrictionsSuite(object):
         steal_plug = stealing.WorkStealing(client.cluster.scheduler)
         assert steal_plug._pc.callback_time == steal_interval
         # assert len(new_worker.task_state)
-

--- a/distributed/benchmarks/client.py
+++ b/distributed/benchmarks/client.py
@@ -56,6 +56,7 @@ class WorkerRestrictionsSuite(object):
         self.client = client
 
     def teardown(self,resource,steal_interval):
+        self.cluster.close()
         self.client.close()
 
     def time_trivial_tasks(self,resource,steal_interval):


### PR DESCRIPTION
If not closing the LocalCluster I'll get a lot of warnings. Not sure if reusing the cluster is an option, didn't dive too deep into the logic there

```
               Perhaps you already have a cluster running?
               Hosting the HTTP server on port 51922 instead
                 http_address["port"], self.http_server.port
```