### PR TITLE
Add benchmarks for Order using Cholesky

### DIFF
--- a/dask/benchmarks/order.py
+++ b/dask/benchmarks/order.py
@@ -162,3 +162,17 @@ class OrderManySubgraphs(DaskSuite):
 
     def time_order_many_subgraphs(self, param):
         order(self.dsk)
+
+
+class OrderCholesky(DaskSuite):
+    def setup(self):
+        n = 50
+        A = da.random.random((n, n), chunks=(1, 1))
+        self.dsk = collections_to_dsk([da.linalg.cholesky(A)])
+        self.dsk_lower = collections_to_dsk([da.linalg.cholesky(A, lower=True)])
+
+    def time_order_cholesky(self):
+        order(self.dsk)
+
+    def time_order_cholesky_lower(self):
+        order(self.dsk_lower)


### PR DESCRIPTION
Cholesky has a very neat pattern.  It uniquely exercises https://github.com/dask/dask/pull/5872 by placing most nodes in `next_nodes` with unique partition keys.  Performing Cholesky with 50x50 partitions places 85% of nodes in `next_nodes` at the same time.

By poking around at this, it appears it's okay to always sort `next_nodes` no matter how large it is.  I suspect this is because time is dominated by `O(E)` edges, not by the number of nodes.

Here's a visualization of a smaller Cholesky (more patterns become apparent the larger it is):
![big-D-1-0-237](https://user-images.githubusercontent.com/2058401/80836677-e3306900-8bba-11ea-9b0d-6960bb51ea75.png)
Any idea why there are so many individual nodes (i.e., the yellow nodes at the bottom)?